### PR TITLE
WindowsにおけるgetSerialList()内変数指定について

### DIFF
--- a/src/Serial.cpp
+++ b/src/Serial.cpp
@@ -265,6 +265,10 @@ std::vector<SerialInfo> getSerialList() {
 			hinfo, &info_data, SPDRP_FRIENDLYNAME, &type, (PBYTE)buff, MAX_PATH, &size)
 			== TRUE) {
 			fullname = buff;
+		}else if (SetupDiGetDeviceRegistryProperty(
+			hinfo, &info_data, SPDRP_DEVICEDESC, &type, (PBYTE)buff, MAX_PATH, &size)
+			== TRUE){
+			fullname = buff;
 		}
 
 		//‚Æ‚è‚ ‚¦‚¸ŠJ‚­

--- a/src/Serial.cpp
+++ b/src/Serial.cpp
@@ -262,7 +262,7 @@ std::vector<SerialInfo> getSerialList() {
 
 		//フレンドリーネーム(fullname)
 		if (SetupDiGetDeviceRegistryProperty(
-			hinfo, &info_data, SPDRP_DEVICEDESC, &type, (PBYTE)buff, MAX_PATH, &size)
+			hinfo, &info_data, SPDRP_FRIENDLYNAME, &type, (PBYTE)buff, MAX_PATH, &size)
 			== TRUE) {
 			fullname = buff;
 		}


### PR DESCRIPTION
コード使わせていただきました、使いやすくてありがたいです

Windowsでの挙動についてですが、SetupDiGetDeviceRegistryProperty()の第3引数は
`SPDRP_DEVICEDESC`ではなく`SPDRP_FRIENDLYNAME`が適切だと思われます。


元のコードですとレジストリエディタでフレンドリーネームを変更した際にも、変更する前のデフォルトの名前で表示されてしまいます

今更かもしれませんが、使わせていただいたことへのお礼として貢献できればと思いプルリクエスト送付させていただきます